### PR TITLE
fix get and set audio stream position

### DIFF
--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -10356,6 +10356,13 @@ function audio_set_volume_channel(audio, channel)
     -- ...
 end
 
+--- @param audio ModAudio
+--- @return integer
+--- Gets the sample rate of an `audio` stream
+function audio_stream_get_sample_rate(audio)
+    -- ...
+end
+
 --- @param filename string
 --- @return ModAudio
 --- Loads an `audio` sample

--- a/docs/lua/functions-6.md
+++ b/docs/lua/functions-6.md
@@ -6018,6 +6018,29 @@ Sets the volume channel of an `audio`
 
 <br />
 
+## [audio_stream_get_sample_rate](#audio_stream_get_sample_rate)
+
+### Description
+Gets the sample rate of an `audio` stream
+
+### Lua Example
+`local integerValue = audio_stream_get_sample_rate(audio)`
+
+### Parameters
+| Field | Type |
+| ----- | ---- |
+| audio | [ModAudio](structs.md#ModAudio) |
+
+### Returns
+- `integer`
+
+### C Prototype
+`u32 audio_stream_get_sample_rate(struct ModAudio* audio);`
+
+[:arrow_up_small:](#)
+
+<br />
+
 ## [audio_sample_load](#audio_sample_load)
 
 ### Description

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -1852,6 +1852,7 @@
    - [audio_stream_set_volume](functions-6.md#audio_stream_set_volume)
    - [audio_get_volume_channel](functions-6.md#audio_get_volume_channel)
    - [audio_set_volume_channel](functions-6.md#audio_set_volume_channel)
+   - [audio_stream_get_sample_rate](functions-6.md#audio_stream_get_sample_rate)
    - [audio_sample_load](functions-6.md#audio_sample_load)
    - [audio_sample_destroy](functions-6.md#audio_sample_destroy)
    - [audio_sample_stop](functions-6.md#audio_sample_stop)

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -30836,6 +30836,23 @@ int smlua_func_audio_set_volume_channel(lua_State* L) {
     return 1;
 }
 
+int smlua_func_audio_stream_get_sample_rate(lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 1) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "audio_stream_get_sample_rate", 1, top);
+        return 0;
+    }
+
+    struct ModAudio* audio = (struct ModAudio*)smlua_to_cobject(L, 1, LOT_MODAUDIO);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "audio_stream_get_sample_rate"); return 0; }
+
+    lua_pushinteger(L, audio_stream_get_sample_rate(audio));
+
+    return 1;
+}
+
 int smlua_func_audio_sample_load(lua_State* L) {
     if (L == NULL) { return 0; }
 
@@ -38745,6 +38762,7 @@ void smlua_bind_functions_autogen(void) {
     smlua_bind_function(L, "audio_stream_set_volume", smlua_func_audio_stream_set_volume);
     smlua_bind_function(L, "audio_get_volume_channel", smlua_func_audio_get_volume_channel);
     smlua_bind_function(L, "audio_set_volume_channel", smlua_func_audio_set_volume_channel);
+    smlua_bind_function(L, "audio_stream_get_sample_rate", smlua_func_audio_stream_get_sample_rate);
     smlua_bind_function(L, "audio_sample_load", smlua_func_audio_sample_load);
     smlua_bind_function(L, "audio_sample_destroy", smlua_func_audio_sample_destroy);
     smlua_bind_function(L, "audio_sample_stop", smlua_func_audio_sample_stop);

--- a/src/pc/lua/utils/smlua_audio_utils.c
+++ b/src/pc/lua/utils/smlua_audio_utils.c
@@ -364,6 +364,11 @@ struct ModAudio* audio_load_internal(const char* filename, enum ModAudioType typ
         return NULL;
     }
 
+    ma_uint32 sampleRate = 0;
+
+    ma_data_source_get_data_format(&audio->decoder, NULL, NULL, &sampleRate, NULL, 0);
+
+    audio->sampleRate = sampleRate;
     audio->buffer = buffer;
     audio->bufferSize = size;
     audio->type = type;
@@ -406,17 +411,27 @@ void audio_stream_stop(struct ModAudio* audio) {
     ma_sound_seek_to_pcm_frame(&audio->sound, 0);
 }
 
+u32 audio_stream_get_sample_rate(struct ModAudio* audio) {
+    if (!audio_sanity_check(audio, MA_TYPE_STREAM, "get sample rate from")) { return 0; }
+
+    return audio->sampleRate;
+}
+
 f32 audio_stream_get_position(struct ModAudio* audio) {
     if (!audio_sanity_check(audio, MA_TYPE_STREAM, "get stream position from")) { return 0; }
 
-    u64 cursor; ma_data_source_get_cursor_in_pcm_frames(&audio->decoder, &cursor);
-    return (f32)cursor / ma_engine_get_sample_rate(&sModAudioEngine);
+    u64 cursor;
+    ma_data_source_get_cursor_in_pcm_frames(&audio->decoder, &cursor);
+
+    return (f32)cursor / (f32)audio->sampleRate;
 }
 
 void audio_stream_set_position(struct ModAudio* audio, f32 pos) {
     if (!audio_sanity_check(audio, MA_TYPE_STREAM, "set stream position for")) { return; }
-    
-    ma_sound_seek_to_pcm_frame(&audio->sound, pos * ma_engine_get_sample_rate(&sModAudioEngine));
+
+    ma_uint64 frame = (ma_uint64)(pos * audio->sampleRate);
+
+    ma_sound_seek_to_pcm_frame(&audio->sound, frame);
 }
 
 bool audio_stream_get_looping(struct ModAudio* audio) {

--- a/src/pc/lua/utils/smlua_audio_utils.h
+++ b/src/pc/lua/utils/smlua_audio_utils.h
@@ -49,6 +49,7 @@ enum ModAudioChannel {
 struct ModAudio {
     ma_sound sound;
     ma_decoder decoder;
+    ma_uint32 sampleRate;
     union {
         struct {
             u8 type    : 2;
@@ -85,6 +86,7 @@ struct ModAudio {
     PROPERTY(frequency, audio_stream_get_frequency, audio_stream_set_frequency);
     PROPERTY(volume,    audio_stream_get_volume,    audio_stream_set_volume);
     PROPERTY(channel,   audio_get_volume_channel,   audio_set_volume_channel);
+    PROPERTY(sampleRate, audio_stream_get_sample_rate, NULL);
 
     PROPERTY(file, return_self, NULL); // compatibility band-aid
 };
@@ -123,6 +125,8 @@ void audio_stream_set_volume(struct ModAudio* audio, f32 volume);
 u8 audio_get_volume_channel(struct ModAudio *audio);
 /* |description|Sets the volume channel of an `audio`|descriptionEnd| */
 void audio_set_volume_channel(struct ModAudio *audio, u8 channel);
+/* |description|Gets the sample rate of an `audio` stream|descriptionEnd| */
+u32 audio_stream_get_sample_rate(struct ModAudio* audio);
 
 void audio_destroy_pending_copies(void);
 /* |description|Loads an `audio` sample|descriptionEnd| */


### PR DESCRIPTION
previous always assumed sample rate, making position calculation incorrect on some audio streams, this fixes it
also new function `audio_stream_get_sample_rate`